### PR TITLE
Adding a bunch of patterns to .gitignore to ignore files created during a build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,20 @@
 *.i*86
 *.x86_64
 *.hex
+
+# build directories
+fmu10/bin
+fmu10/fmu
+fmu20/bin
+fmu20/fmu
+fmu10/src/models/*/fmu/
+fmu10/src/fmusim_cs
+fmu10/src/fmusim_cs.dSYM
+fmu10/src/fmusim_me
+fmu10/src/fmusim_me.dSYM
+fmu20/src/fmusim_cs
+fmu20/src/fmusim_cs.dSYM
+fmu20/src/fmusim_me
+fmu20/src/fmusim_me.dSYM
+fmu20/src/models/*/fmu/
+


### PR DESCRIPTION
Christopher,

  I noticed the .gitignore files didn't cover all the generated files so I added some additional patterns. I
think this should be fine and it avoids accidentally committing a binary file or other generated files.
