### PR TITLE
Fix warnings about incompatible pointer types.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ fmu20/src/fmusim_me
 fmu20/src/fmusim_me.dSYM
 fmu20/src/models/*/fmu/
 
+# temp folders
+/fmuTmp*
+
+# simulation results
+/result_*

--- a/fmu20/src/co_simulation/main.c
+++ b/fmu20/src/co_simulation/main.c
@@ -36,7 +36,7 @@ FMU fmu; // the fmu to simulate
 
 // simulate the given FMU from tStart = 0 to tEnd.
 static int simulate(FMU* fmu, double tEnd, double h, fmi2Boolean loggingOn, char separator,
-                    int nCategories, const fmi2String *categories) {
+                    int nCategories, const fmi2String categories[]) {
     double time;
     double tStart = 0;                      // start time
     const char *guid;                       // global unique id of the fmu
@@ -144,7 +144,7 @@ int main(int argc, char *argv[]) {
     double h=0.1;
     int loggingOn = 0;
     char csv_separator = ',';
-    const fmi2String *categories = NULL;
+    fmi2String *categories = NULL;
     int nCategories = 0;
 
     parseArguments(argc, argv, &fmuFileName, &tEnd, &h, &loggingOn, &csv_separator, &nCategories, &categories);

--- a/fmu20/src/model_exchange/main.c
+++ b/fmu20/src/model_exchange/main.c
@@ -38,7 +38,7 @@ FMU fmu; // the fmu to simulate
 // state events are checked and fired only at the end of an Euler step. 
 // the simulator may therefore miss state events and fires state events typically too late.
 static int simulate(FMU* fmu, double tEnd, double h, fmi2Boolean loggingOn, char separator,
-                    int nCategories, char **categories) {
+                    int nCategories, const fmi2String categories[]) {
     int i;
     double dt, tPre;
     fmi2Boolean timeEvent, stateEvent, stepEvent, terminateSimulation;
@@ -259,7 +259,7 @@ int main(int argc, char *argv[]) {
     double h=0.1;
     int loggingOn = 0;
     char csv_separator = ',';
-    char **categories = NULL;
+    fmi2String *categories = NULL;
     int nCategories = 0;
 
     parseArguments(argc, argv, &fmuFileName, &tEnd, &h, &loggingOn, &csv_separator, &nCategories, &categories);


### PR DESCRIPTION
This small PR fixes the compile warnings about incompatible pointer types and adds the temporary folders and simulation results to the gitignore-file.